### PR TITLE
Old flipsum link no longer live; CORS issue resolved on server side

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,6 +46,6 @@ window.addEventListener('keydown', (event) => {
   inputTextbox.value += key
 })
 
-fetch('https://tauro.id/flipsum.php')
+fetch('https://power-plugins.com/api/flipsum/ipsum/coffee-shop?paragraphs=4&start_with_fixed=0')
   .then(response => response.json())
   .then(processFetchedText)


### PR DESCRIPTION
- the flipsum group have changed their links - now they all start `https://power-plugins.com/api/` - so the link we've been using doesn't work now
- I contacted them about the CORS issue and they solved it at their end